### PR TITLE
docs(readme): add a step to resolve the issue of opening the app on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,22 @@ sudo apt-get install -f
 
 ```
 
+
+
+#### Using AppImage file
+```bash
+# Download the latest release
+wget https://github.com/ropali/dockyard/releases/download/vX.Y.Z/dockyard-X.Y.Z.AppImage
+
+# Make it executable
+chmod +x dockyard-X.Y.Z.AppImage
+
+# Run Dockyard
+./dockyard-X.Y.Z.AppImage
+```
+
+#### MacOS Installation Issue
 > [!NOTE]
-> **macOS aarch64 Installation Issue:**
 > 
 > Due to Apple's security policies, software without developer certification cannot be installed directly. To bypass this restriction, follow these steps:
 > 
@@ -94,19 +108,6 @@ sudo apt-get install -f
 >```
 >
 
-
-
-#### Using AppImage file
-```bash
-# Download the latest release
-wget https://github.com/ropali/dockyard/releases/download/vX.Y.Z/dockyard-X.Y.Z.AppImage
-
-# Make it executable
-chmod +x dockyard-X.Y.Z.AppImage
-
-# Run Dockyard
-./dockyard-X.Y.Z.AppImage
-```
 
 ### Build from Source
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ cargo build --release
 npm run tauri dev
 ```
 
-
 ## Usage
 
 Dockyard is designed to be simple and intuitive. Once installed, launch the application and start managing your Docker containers, volumes, and networks. 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,27 @@ sudo apt-get install -f
 
 ```
 
+> [!NOTE]
+> **macOS aarch64 Installation Issue:**
+> 
+> Due to Apple's security policies, software without developer certification cannot be installed directly. To bypass this restriction, follow these steps:
+> 
+> - Click the Cancel button
+> 
+> - Go to System Preferences -> Security & Privacy
+>
+> - Click Open Anyway, and then click Open in the pop-up window. 
+>
+> If your system version is higher, you may not find the above options on the Security & Privacy page, or it may prompt that the file is damaged when you start it. then, you can bypass via terminal:
+>
+> - Open the terminal and execute the following command to authorize.
+>
+>```bash
+>sudo xattr -d com.apple.quarantine /Applications/dockyard.app/
+>```
+>
+
+
 
 #### Using AppImage file
 ```bash
@@ -105,6 +126,7 @@ cargo build --release
 # Run the app in development mode
 npm run tauri dev
 ```
+
 
 ## Usage
 


### PR DESCRIPTION
I just added a step in the README on how to resolve issues with the app due to unsigned binaries in macOS.


![CleanShot 2024-09-23 at 12 26 40](https://github.com/user-attachments/assets/9c855c23-f193-4d09-aa2d-b1da419f5b41)
