### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ To set up a development environment:
 2. Navigate to the project directory: `cd dockyard`
 3. Install Node.js dependencies: `yarn install`
 4. Build the Rust backend: `cargo build --release`
-5. Run the app in development mode: `cargo tauri dev`
+5. Run the app in development mode: `npm run tauri dev`
 
 ## Roadmap
 


### PR DESCRIPTION
The command for building from source requires an additional "cd src-tauri" in order to be valid.

Also the command for running dev is wrong, as ```cargo tauri dev``` is invalid.