### PR TITLE
feat: use connect_with_defaults instead of connect_with_socket_defaults

### DIFF
--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -10,7 +10,7 @@ pub struct AppState {
 
 impl AppState {
     pub fn default() -> Self {
-        let docker = match Docker::connect_with_socket_defaults() {
+        let docker = match Docker::connect_with_defaults() {
             Ok(docker) => docker,
             Err(e) => {
                 panic!("Failed To Connect: {}", e);


### PR DESCRIPTION
This allows for easier connection with alternative runtimes like podman by respecting the DOCKER_HOST environment variable. In case of its absence, bollard does a standard fallback like connect_with_socket_defaults does as well, retaining the previous functionality.