### PR TITLE
fix: prevent overflow for local image hash

### DIFF
--- a/src/components/Containers/ContainerCard.tsx
+++ b/src/components/Containers/ContainerCard.tsx
@@ -23,12 +23,12 @@ const ContainerCard = ({ container, onClick, isSelected }: ContainerCardProps) =
                 <div className={`w-3 h-3 rounded-full ${statusColor} mr-2`}></div>
                 <h1 className="text-sm font-semibold">{container.getName()}</h1>
             </div>
-            <div className="mb-1">
+            <div className="mb-1 mr-4">
                 <p className="text-xs ">
                     <span className="font-medium">ID:</span> {container.Id.slice(0, 7)}
                 </p>
-                <p className="text-xs ">
-                    <span className="font-medium">Image:</span> {container.Image.split(':')[0]}
+                <p className="text-xs truncate" title={container.getImageName()}>
+                    <span className="font-medium">Image:</span> {container.getImageName()}
                 </p>
             </div>
             <div className="flex justify-between items-center">

--- a/src/models/Container.ts
+++ b/src/models/Container.ts
@@ -23,6 +23,10 @@ export class Container implements Docker.Container {
         return this.Names[0].slice(1);
     }
 
+    getImageName(): string {
+        return this.Image.split(':')[0];
+    }
+
     isRunning(): boolean {
         return this.State.toLowerCase() === 'running';
     }


### PR DESCRIPTION
When building local images, the name/hash can be too long, causing an unwanted overflow.
Prevent this from happening by adding overflow: ellipsis and some margin to prevent overlap with the ">"  instead.

Before:
![image](https://github.com/user-attachments/assets/82124297-fd0a-4354-a29f-cf69dd91aa80)


After:
![image](https://github.com/user-attachments/assets/ca1629d7-caf2-4f24-b528-11bebb8e41f2)
